### PR TITLE
feat: enable multi-architecture Docker builds (amd64 + arm64)

### DIFF
--- a/.github/workflows/build-release-docker-hub.yml
+++ b/.github/workflows/build-release-docker-hub.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.prep.outputs.tags }}
           labels: |

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,6 @@ services:
       - .env
     build:
       dockerfile: ./Dockerfile
-    platform: linux/x86_64
     # depends_on:
     #   rabbitmq:
     #     condition: "service_healthy"
@@ -26,8 +25,6 @@ services:
     image: rabbitmq:3-management-alpine
     extra_hosts:
       - "host.docker.internal:host-gateway"
-
-    platform: linux/x86_64
     container_name: "rabbitmq"
     healthcheck:
       test: rabbitmq-diagnostics check_port_connectivity


### PR DESCRIPTION
## Summary
- Enable multi-architecture Docker image builds for linux/amd64 and linux/arm64
- Updated `.github/workflows/build-release-docker-hub.yml` to build for both platforms
- Removed `platform: linux/x86_64` from all services in `docker-compose.yaml`

## Notes
- QEMU and Docker Buildx were already configured, just needed to add arm64 to platforms
- Base images (debian:bookworm-slim, distroless/python3-debian12) support multi-architecture

## Test plan
- [ ] Verify GitHub Actions workflow runs successfully
- [ ] Verify multi-arch manifest is created on Docker Hub
- [ ] Test image pull and run on both amd64 and arm64 machines
- [ ] Verify docker-compose works on both architectures